### PR TITLE
Add host and port to database secret

### DIFF
--- a/vault/database.go
+++ b/vault/database.go
@@ -3,9 +3,47 @@ package vault
 import (
 	"fmt"
 	"github.com/hashicorp/vault/api"
+	"net"
+	"net/url"
+	"regexp"
 	"time"
 )
 
+func (c *Client) getDatabaseUrl(path string, dbName string) (string, error) {
+	dbConfig, err := c.client.Logical().ReadWithData(path+"/config/"+dbName, map[string][]string{})
+	if err != nil {
+		return "", fmt.Errorf("cannot get config for db %s", dbName)
+	}
+
+	dbConnectionDetails, ok := dbConfig.Data["connection_details"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("cannot unmarshal connection_details from vault db config %s", dbName)
+	}
+
+	connectionUrl, ok := dbConnectionDetails["connection_url"].(string)
+	if !ok {
+		return "", fmt.Errorf("cannot unmarshal connection_url from connection_details of db %s", dbName)
+	}
+
+	return connectionUrl, nil
+}
+
+// extractHostPort takes a connectionUrl received from Vault and returns its host and port
+// We assume that port is always set.
+func extractHostPort(connectionUrl string) (string, string, error) {
+	re := regexp.MustCompile(`{{[^}}]+}}`)
+	s := re.ReplaceAll([]byte(connectionUrl), []byte("T"))
+
+	u, err := url.Parse(string(s))
+	if err != nil {
+		return "", "", err
+	}
+
+	return net.SplitHostPort(u.Host)
+}
+
+// Get username/password/host/port for a Vault Database role
+// Host and port are extracted from the configuration of the database
 func (c *Client) GetDatabaseCreds(path string, role string) (*api.Secret, *time.Time, error) {
 	secret, err := c.client.Logical().ReadWithData(path+"/creds/"+role, map[string][]string{})
 	if err != nil {
@@ -19,9 +57,29 @@ func (c *Client) GetDatabaseCreds(path string, role string) (*api.Secret, *time.
 	secret.LeaseDuration = 2600000
 	expiresAt := time.Now().Add(time.Duration(secret.LeaseDuration) * time.Second)
 
+	roleSecret, err := c.client.Logical().ReadWithData(path+"/roles/"+role, map[string][]string{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dbName, ok := roleSecret.Data["db_name"].(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("cannot cast db_name to string for role %s", role)
+	}
+
+	connectionUrl, _ := c.getDatabaseUrl(path, dbName)
+
+	host, port, err := extractHostPort(connectionUrl)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot extract host and port from connection url %s", connectionUrl)
+	}
+
+	secret.Data["host"] = host
+	secret.Data["port"] = port
+
 	return secret, &expiresAt, nil
 }
 
 func (c *Client) DatabaseRenderData(secret *api.Secret) (map[string][]byte, error) {
-	return convertData(secret.Data, []string{"username", "password"}, false)
+	return convertData(secret.Data, []string{"host", "port", "username", "password"}, false)
 }


### PR DESCRIPTION
```json
# vault read -format=json rvse/staging/roles/medical-beta-cmie-beta-cmie_wellinjob-rw
{
  "request_id": "b847f6a9-98db-d3dc-dad3-5a4e136ae520",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "creation_statements": [
      "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}' INHERIT;\n    GRANT owner TO \"{{name}}\";"
    ],
    "credential_type": "password",
    "db_name": "medical-beta-cmie",
    "default_ttl": 5184000,
    "max_ttl": 7776000,
    "renew_statements": [],
    "revocation_statements": [],
    "rollback_statements": []
  },
  "warnings": null
}
```

Get `data.db_name` from response and fetch `data.connection_details.connection_url`

```json
# vault read -format=json rvse/staging/config/medical-beta-cmie
{
  "request_id": "46806d7f-5cfd-a2a3-2838-ddc9d30d1239",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "allowed_roles": [
      "medical-beta-cmie-beta-cmie_authentication-ro",
      "medical-beta-cmie-beta-cmie_authentication-rw",
      "medical-beta-cmie-beta-cmie_notifications-ro",
      "medical-beta-cmie-beta-cmie_notifications-rw",
      "medical-beta-cmie-beta-cmie_wellinjob-ro",
      "medical-beta-cmie-beta-cmie_wellinjob-rw"
    ],
    "connection_details": {
      "connection_url": "postgres://{{username}}:{{password}}@medical-beta-cmie-primary.medical-beta-cmie.svc:5432/postgres?sslmode=require",
      "disable_escaping": false,
      "max_open_connections": 2,
      "username": "vault"
    },
    "password_policy": "",
    "plugin_name": "postgresql-database-plugin",
    "root_credentials_rotate_statements": []
  },
  "warnings": null
}
```

# TODO

- [ ] Mettre à jour la documentation
- [ ] Ajouter des commentaires