### PR TITLE
feat: add cost labels to vault-secrets-operator pods

### DIFF
--- a/charts/vault-secrets-operator/values.padoa.yaml
+++ b/charts/vault-secrets-operator/values.padoa.yaml
@@ -1,5 +1,10 @@
 replicaCount: 2
 
+# Padoa cost-allocation labels applied to the operator pods.
+podLabels:
+  costs.padoa.fr/client: undefined
+  costs.padoa.fr/component: infra.vault-secrets-operator
+
 # override this on some envs
 resources:
   limits:


### PR DESCRIPTION
Add Padoa cost-allocation labels (`costs.padoa.fr/client`, `costs.padoa.fr/component`) to the vault-secrets-operator controller pod template via the chart's existing `podLabels` value, set in `values.padoa.yaml`.

ref SRE-8156
